### PR TITLE
Fixed systemd ExecStart command to include parameters explicitly

### DIFF
--- a/templates/etc/systemd/system/carbon-c-relay.service.erb
+++ b/templates/etc/systemd/system/carbon-c-relay.service.erb
@@ -7,7 +7,7 @@ After=network.target
 EnvironmentFile=/etc/sysconfig/<%= @package_name %>
 User=<%= @user %>
 Group=<%= @group %>
-ExecStart=/bin/carbon-c-relay -f <%= @config_file %> $ARGS
+ExecStart=/bin/carbon-c-relay -f <%= @config_file %> -p <%= @listen %> -w <%= @worker_threads %> -b <%= @server_batch_size %> -q <%= @server_queue_size %> -l <%= @log_dir %>/<%= @log_file %>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This seemed to be problematic on RHEL 7, as the relay did not properly log to the specified log file.
