### PR TITLE
Added option to set order of match rule via hiera/params. Default val…

### DIFF
--- a/manifests/config/match.pp
+++ b/manifests/config/match.pp
@@ -2,13 +2,13 @@
 define carbon_c_relay::config::match (
   $cluster_name = 'blackhole',
   $expression   = $title,
+  $order        = '30',
   $stop         = false
 ){
 
   concat::fragment { "match-${title}":
     target  => $carbon_c_relay::config_file,
     content => template('carbon_c_relay/config/match.erb'),
-    order   => '30'
+    order   => $order
   }
 }
-

--- a/manifests/config/rewrite.pp
+++ b/manifests/config/rewrite.pp
@@ -8,6 +8,6 @@ define carbon_c_relay::config::rewrite (
   concat::fragment { "rewrite-${title}":
     target  => $carbon_c_relay::config_file,
     content => template('carbon_c_relay/config/rewrite.erb'),
-    order   => '40'
+    order   => '90'
   }
 }


### PR DESCRIPTION
…ue is now 30. Increased value of default for rewrite rules, so that collisions of ordering are unlikely (order of rewrite now is 90, so you can define 60 matching rules without any issues)
