### PR TITLE
add reload to unit file

### DIFF
--- a/templates/usr/lib/systemd/system/carbon-c-relay.service.erb
+++ b/templates/usr/lib/systemd/system/carbon-c-relay.service.erb
@@ -8,6 +8,7 @@ User=<%= @user %>
 Group=<%= @group %>
 EnvironmentFile=/etc/sysconfig/<%= @service_name %>
 ExecStart=/bin/carbon-c-relay -f <%= @config_file %> $ARGS
+ExecReload=/bin/kill -HUP ${MAINPID}
 Type=simple
 <% if @limit_fsize -%>
 # (file size)


### PR DESCRIPTION
This add the reload function to the systemd unit file. systemctl reload carbon-c-relay will now trigger a sighup to carbon-c-relay which will reload the config
