### PR TITLE
Check carbon-c-relay version for configuring later introduced settings

### DIFF
--- a/lib/facter/carbon_c_relay_version.rb
+++ b/lib/facter/carbon_c_relay_version.rb
@@ -1,0 +1,12 @@
+require 'facter'
+
+Facter.add('carbon_c_relay_rpm_version') do
+  setcode do
+    version = Facter::Util::Resolution.exec('/bin/rpm -q --queryformat "%{VERSION}" carbon-c-relay')
+    if version
+      version.match(/^\d+.*$/).to_s
+    else
+      nil
+    end
+  end
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,7 @@
 #
 class carbon_c_relay::config (
   $allowed_chars               = $carbon_c_relay::allowed_chars,
+  $carbon_c_relay_version      = $carbon_c_relay::carbon_c_relay_version,
   $carbon_cache_statistics     = $carbon_c_relay::carbon_cache_statistics,
   $config_file                 = $carbon_c_relay::config_file,
   $group                       = $carbon_c_relay::group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,14 @@
 # Specify server max stalls
 # Default: 4
 #
+# [*minimum_version*]
+# Some configuration options are only supported in newer carbon-c-relay
+# releases. The rpm package version fact is fetched at the start of each
+# Puppet run to determine which which options to enable. On initial Puppet run
+# this variable is empty and not all configuration options can be set. To
+# prevent the need for multiple runs the `minimum_version` can be set.
+# Default: '0.0'
+#
 # [*ouput_file*]
 # Specify to which file carbon-c-relay should redirect its output
 #
@@ -156,6 +164,7 @@ class carbon_c_relay (
   $log_dir                     = $carbon_c_relay::params::log_dir,
   $log_file                    = $carbon_c_relay::params::log_file,
   $max_stalls                  = $carbon_c_relay::params::max_stalls,
+  $minimum_version             = $carbon_c_relay::params::minimum_version,
   $output_file                 = $carbon_c_relay::params::output_file,
   $package_ensure              = $carbon_c_relay::params::package_ensure,
   $package_manage              = $carbon_c_relay::params::package_manage,
@@ -218,6 +227,7 @@ class carbon_c_relay (
     $interface,
     $log_dir,
     $log_file,
+    $minimum_version,
     $output_file,
     $package_ensure,
     $package_name,
@@ -229,6 +239,8 @@ class carbon_c_relay (
     $sysconfig_template,
     $user,
   )
+
+  $carbon_c_relay_version = pick($::carbon_c_relay_rpm_version, $minimum_version)
 
   anchor { 'carbon_c_relay::begin': }
   -> class { '::carbon_c_relay::install': }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,7 @@ class carbon_c_relay::params {
   $log_dir                     = '/var/log/carbon-c-relay'
   $log_file                    = 'carbon-c-relay.log'
   $max_stalls                  = 4
+  $minimum_version             = '0.0'
   $output_file                 = undef
   $package_ensure              = latest
   $package_manage              = true

--- a/templates/etc/sysconfig/carbon-c-relay.erb
+++ b/templates/etc/sysconfig/carbon-c-relay.erb
@@ -16,7 +16,7 @@
 #   -B  connection listen backlog, defaults to 3
 #   -T  IO timeout in milliseconds for server connections, defaults to 600
 #   -m  send statistics like carbon-cache.py, e.g. not cumulative
-#   -c  characters to allow next to [A-Za-z0-9], defaults to -_:# 
+#   -c  characters to allow next to [A-Za-z0-9], defaults to -_:#
 #   -d  debug mode: currently writes statistics to log, prints hash
 #       ring contents and matching position in test mode (-t)
 #   -s  submission mode: don't add any metrics to the stream like
@@ -24,4 +24,16 @@
 #   -t  config test mode: prints rule matches from input on stdin
 #   -H  hostname: override hostname (used in statistics)
 
-ARGS=-p <%= @listen %> -i <%= @interface %> -w <%= @worker_threads %> -b <%= @server_batch_size %> -q <%= @server_queue_size %> -l <%= @log_dir %>/<%= @log_file %><% if @max_stalls -%> -L <%= @max_stalls %><% end -%><% if @listen_backlog -%> -B <%= @listen_backlog %><% end -%><% if @io_timeout -%> -T <%= @io_timeout %><% end -%><% if @carbon_cache_statistics -%> -m <% end -%><% if @statistics_sending_interval -%> -S <%= @statistics_sending_interval %><% end -%><% if @allowed_chars -%> -c <%= @allowed_chars %><% end -%><% if @statistics_hostname -%> -H <%= @statistics_hostname %><% end -%>
+ARGS= -p <%= @listen -%>
+ -i <%= @interface -%>
+ -w <%= @worker_threads -%>
+ -b <%= @server_batch_size -%>
+ -q <%= @server_queue_size -%>
+ -l <%= @log_dir %>/<%= @log_file -%>
+<% if scope.function_versioncmp([@carbon_c_relay_version, '2.0']) >= 0 -%> -L <%= @max_stalls %><% end -%>
+<% if scope.function_versioncmp([@carbon_c_relay_version, '1.7']) >= 0 -%> -B <%= @listen_backlog %><% end -%>
+<% if @io_timeout -%> -T <%= @io_timeout %><% end -%>
+<% if @carbon_cache_statistics -%> -m <% end -%>
+<% if @statistics_sending_interval -%> -S <%= @statistics_sending_interval %><% end -%>
+<% if @allowed_chars -%> -c <%= @allowed_chars %><% end -%>
+<% if @statistics_hostname -%> -H <%= @statistics_hostname %><% end %>


### PR DESCRIPTION
This checks the version from the carbon-c-relay rpm package to determine which settings are supported by the installed carbon-c-relay. To prevent double runs minimum_version can be configured.

carbon-c-relay.erb template split line to make the template better human readable.
